### PR TITLE
Only coerce the SNat, not the Either constructor.

### DIFF
--- a/src/GHC/TypeLits/Witnesses.hs
+++ b/src/GHC/TypeLits/Witnesses.hs
@@ -293,7 +293,7 @@ minusSNat
     -> Either (CmpNat n m :~: 'LT) (SNat (n - m))
 minusSNat (fromSNat->x) (fromSNat->y) = case minusNaturalMaybe x y of
     Nothing -> Left (unsafeCoerce Refl)
-    Just z  -> withSomeNat z unsafeCoerce
+    Just z  -> withSomeNat z (Right . unsafeCoerce)
 
 -- | A version of 'minusSNat' that just returns a 'Maybe'.
 minusSNat_ :: SNat n -> SNat m -> Maybe (SNat (n - m))


### PR DESCRIPTION
Without this change, `minusSNat` always returns a `Left` value,
either because it *should* return Left, or else because we've
coerced a SNat into an Either _ _, which gives us something `Left`(!)