### PR TITLE
Include generated Cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /.cabal-sandbox
 /dist
 /.stack-work
-/typelits-witnesses.cabal
 /.ghc.environment.*
 /dist-newstyle

--- a/typelits-witnesses.cabal
+++ b/typelits-witnesses.cabal
@@ -1,0 +1,52 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           typelits-witnesses
+version:        0.4.0.0
+synopsis:       Existential witnesses, singletons, and classes for operations on GHC TypeLits
+description:    This library contains:
+                .
+                *   A small specialized subset of the *singletons* library as it pertains to
+                    `Nat` and `Symbol`, for when you need some simple functionality without
+                    wanting to invoke the entire *singletons* library.
+                *   Operations for manipulating these singletons and `KnownNat` and
+                    `KnownSymbol` instances, such as addition and multiplication of
+                    singletons/`KnownNat` instances.
+                *   Operations for the comparison of `Nat`s in a way that works well with
+                    *GHC.TypeLits*'s different comparison systems.  This is helpful for
+                    bridging together libraries that use different systems; this functionality
+                    is not yet provided by *singletons*.
+category:       Data
+homepage:       https://github.com/mstksg/typelits-witnesses
+author:         Justin Le
+maintainer:     justin@jle.im
+copyright:      (c) Justin Le 2018
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+tested-with:
+    GHC>=8.2
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: git://github.com/mstksg/typelits-witnesses.git
+
+library
+  exposed-modules:
+      GHC.TypeLits.Compare
+      GHC.TypeLits.Witnesses
+  other-modules:
+      Paths_typelits_witnesses
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wredundant-constraints -Werror=incomplete-patterns -Wcompat
+  build-depends:
+      base >=4.10 && <5
+    , dependent-sum
+  default-language: Haskell2010


### PR DESCRIPTION
When using this package as a Git dependency with Stack, it generates a deprecation warning referencing https://github.com/commercialhaskell/stack/issues/5210. This fixes that warning.