### PR TITLE
Compatability with GHC-9.4 & GHC-9.6 via CPP for `cmpNat`

### DIFF
--- a/src/GHC/TypeLits/Compare.hs
+++ b/src/GHC/TypeLits/Compare.hs
@@ -96,7 +96,9 @@ module GHC.TypeLits.Compare
 
 import           Data.Kind
 import           Data.Type.Equality
-import           GHC.TypeLits
+import           GHC.TypeLits ( Nat, KnownNat, CmpNat
+                              , type (<=?)
+                              , natVal )
 import           Unsafe.Coerce
 import           Data.GADT.Compare
 

--- a/src/GHC/TypeLits/Witnesses.hs
+++ b/src/GHC/TypeLits/Witnesses.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
@@ -8,7 +9,11 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 {-# LANGUAGE NoStarIsType              #-}
+#if MIN_VERSION_base(4,18,0)
+{-# LANGUAGE DataKinds                 #-}
+#else
 {-# LANGUAGE TypeInType                #-}
+#endif
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE ViewPatterns              #-}
 
@@ -121,10 +126,18 @@ import           Data.Type.Equality
 import           GHC.Natural
 import           GHC.TypeLits ( KnownSymbol, SomeSymbol(..)
                               , symbolVal, someSymbolVal, sameSymbol )
+#if MIN_VERSION_base(4,16,0)
 import           GHC.TypeLits.Compare hiding ((%<=?))
+#else
+import           GHC.TypeLits.Compare hiding (cmpNat, (%<=?))
+#endif
 import           GHC.TypeNats ( KnownNat, SomeNat(..), CmpNat
                               , type (+), type (-), type (*), type (^)
+#if MIN_VERSION_base(4,16,0)
                               , natVal, someNatVal, sameNat )
+#else
+                              , cmpNat, natVal, someNatVal, sameNat )
+#endif
 import           Unsafe.Coerce
 import qualified GHC.TypeLits.Compare        as Comp
 
@@ -330,7 +343,11 @@ x@SNat %<=? y@SNat = x Comp.%<=? y
 -- | Compare @n@ and @m@, categorizing them into one of the constructors of
 -- 'SCmpNat'.
 sCmpNat :: SNat n -> SNat m -> SCmpNat n m
+#if MIN_VERSION_base(4,16,0)
+sCmpNat x@SNat y@SNat = cmpNat' x y
+#else
 sCmpNat x@SNat y@SNat = cmpNat x y
+#endif
 
 -- | An @'SSymbol' n@ is a witness for @'KnownSymbol' n@.
 --

--- a/src/GHC/TypeLits/Witnesses.hs
+++ b/src/GHC/TypeLits/Witnesses.hs
@@ -119,9 +119,12 @@ import           Data.GADT.Show
 import           Data.Proxy
 import           Data.Type.Equality
 import           GHC.Natural
-import           GHC.TypeLits hiding         (natVal, someNatVal)
+import           GHC.TypeLits ( KnownSymbol, SomeSymbol(..)
+                              , symbolVal, someSymbolVal, sameSymbol )
 import           GHC.TypeLits.Compare hiding ((%<=?))
-import           GHC.TypeNats
+import           GHC.TypeNats ( KnownNat, SomeNat(..), CmpNat
+                              , type (+), type (-), type (*), type (^)
+                              , natVal, someNatVal, sameNat )
 import           Unsafe.Coerce
 import qualified GHC.TypeLits.Compare        as Comp
 

--- a/typelits-witnesses.cabal
+++ b/typelits-witnesses.cabal
@@ -1,0 +1,53 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 8a6351c34d982cd0199ea26cf5f6378e136998abb7019115d627268f8977bdda
+
+name:           typelits-witnesses
+version:        0.4.0.0
+synopsis:       Existential witnesses, singletons, and classes for operations on GHC TypeLits
+description:    This library contains:
+                .
+                *   A small specialized subset of the *singletons* library as it pertains to
+                    `Nat` and `Symbol`, for when you need some simple functionality without
+                    wanting to invoke the entire *singletons* library.
+                *   Operations for manipulating these singletons and `KnownNat` and
+                    `KnownSymbol` instances, such as addition and multiplication of
+                    singletons/`KnownNat` instances.
+                *   Operations for the comparison of `Nat`s in a way that works well with
+                    *GHC.TypeLits*'s different comparison systems.  This is helpful for
+                    bridging together libraries that use different systems; this functionality
+                    is not yet provided by *singletons*.
+category:       Data
+homepage:       https://github.com/mstksg/typelits-witnesses
+author:         Justin Le
+maintainer:     justin@jle.im
+copyright:      (c) Justin Le 2018
+license:        MIT
+license-file:   LICENSE
+tested-with:    GHC>=8.2 && <8.8
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: git://github.com/mstksg/typelits-witnesses.git
+
+library
+  exposed-modules:
+      GHC.TypeLits.Compare
+      GHC.TypeLits.Witnesses
+  other-modules:
+      Paths_typelits_witnesses
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wredundant-constraints -Werror=incomplete-patterns -Wcompat
+  build-depends:
+      base >=4.10 && <5
+    , dependent-sum
+  default-language: Haskell2010

--- a/typelits-witnesses.cabal
+++ b/typelits-witnesses.cabal
@@ -51,3 +51,4 @@ library
       base >=4.10 && <5
     , dependent-sum
   default-language: Haskell2010
+  other-extensions: CPP


### PR DESCRIPTION
There exists a name clash with `cmpNat` exported from `GHC.TypeLits` since `base-4.16.0.0`. I corrected this via a quick application of `CPP`. The libary now successfully compiler with `ghc-9.4.*` and `ghc-9.6.*`.

While adding `CPP` clauses, I conditionally included the `TypeInType` language extension to suppress the warnings with `ghc-9.6.*`.

Merging would be nice for continued forwards compatibility. The `typelits-witnesses` package is a dependency of the very nice `finitary` package. It would be great to keep both working with modern version of GHC.