### PR TITLE
Depend on `some` instead of `dependent-sum`

### DIFF
--- a/typelits-witnesses.cabal
+++ b/typelits-witnesses.cabal
@@ -52,6 +52,6 @@ library
 
   build-depends:
       base           >=4.10 && <5
-    , dependent-sum
+    , some
 
   default-language: Haskell2010


### PR DESCRIPTION
`some` is a much cleaner package to depend on than `dependent-sum` (it doesn't depend indirectly on `aeson` for example).